### PR TITLE
feat: implemented Payment management with Stripe integration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -131,6 +131,12 @@
             <artifactId>liquibase-maven-plugin</artifactId>
             <version>${liquibase.version}</version>
         </dependency>
+        <!-- Stripe dependency -->
+        <dependency>
+            <groupId>com.stripe</groupId>
+            <artifactId>stripe-java</artifactId>
+            <version>28.2.0</version>
+        </dependency>
     </dependencies>
 
     <dependencyManagement>

--- a/src/main/java/mate/academy/bookingapp/config/StripeConfig.java
+++ b/src/main/java/mate/academy/bookingapp/config/StripeConfig.java
@@ -1,0 +1,17 @@
+package mate.academy.bookingapp.config;
+
+import com.stripe.Stripe;
+import jakarta.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class StripeConfig {
+    @Value("${stripe.api.secret-key}")
+    private String stripeSecretKey;
+
+    @PostConstruct
+    public void initStripe() {
+        Stripe.apiKey = stripeSecretKey;
+    }
+}

--- a/src/main/java/mate/academy/bookingapp/controller/PaymentController.java
+++ b/src/main/java/mate/academy/bookingapp/controller/PaymentController.java
@@ -1,0 +1,95 @@
+package mate.academy.bookingapp.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import mate.academy.bookingapp.dto.payment.PaymentDto;
+import mate.academy.bookingapp.service.payment.PaymentService;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Tag(name = "Payment Management", description = "Endpoints for managing payments")
+@RestController
+@RequestMapping("/payments")
+@RequiredArgsConstructor
+public class PaymentController {
+    private final PaymentService paymentService;
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @Operation(summary = "Create a payment session",
+            description = "Create a new payment session for a specific booking."
+                    + " Returns session details.")
+    public PaymentDto createPayment(
+            @RequestParam("bookingId") Long bookingId,
+            UriComponentsBuilder uriBuilder) {
+
+        UriComponentsBuilder uriComponents = (UriComponentsBuilder) uriBuilder.clone();
+        String successUrl = uriBuilder
+                .path("/payments/success")
+                .queryParam("sessionId", "{CHECKOUT_SESSION_ID}")
+                .build()
+                .toUriString();
+
+        String cancelUrl = uriComponents
+                .path("/payments/cancel")
+                .queryParam("sessionId", "{CHECKOUT_SESSION_ID}")
+                .build()
+                .toUriString();
+
+        return paymentService.createPaymentSession(bookingId, successUrl, cancelUrl);
+    }
+
+    @GetMapping("/success")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @Operation(summary = "Handle successful payment",
+            description = "Processes a successful payment using the Stripe session ID.")
+    public String success(@RequestParam("sessionId") String sessionId) {
+        return paymentService.handleSuccess(sessionId);
+    }
+
+    @GetMapping("/cancel")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @Operation(summary = "Handle canceled payment",
+            description = "Handles a canceled payment session and updates"
+                    + " the payment and booking statuses.")
+    public String cancel(@RequestParam("sessionId") String sessionId) {
+        return paymentService.handleCancel(sessionId);
+    }
+
+    @GetMapping("/my")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @Operation(summary = "Get current user's payments",
+            description = "Retrieve a paginated list of payments for "
+                    + "the currently authenticated user.")
+    public Page<PaymentDto> getCurrentUserPayments(Pageable pageable) {
+        return paymentService.getCurrentUserPayments(pageable);
+    }
+
+    @GetMapping
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @Operation(summary = "Get payments by user ID",
+            description = "Retrieve a paginated list of payments for a specific user. Admins only.")
+    public Page<PaymentDto> getPaymentsByUserId(
+            @RequestParam("userId") Long userId, Pageable pageable) {
+        return paymentService.findAllByUserId(userId, pageable);
+    }
+
+    @GetMapping("/all")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @Operation(summary = "Get all payments",
+            description = "Retrieve a paginated list of all payments. Admins only.")
+    public Page<PaymentDto> getAllPayments(Pageable pageable) {
+        return paymentService.getAllPayments(pageable);
+    }
+}

--- a/src/main/java/mate/academy/bookingapp/dto/payment/PaymentDto.java
+++ b/src/main/java/mate/academy/bookingapp/dto/payment/PaymentDto.java
@@ -1,0 +1,15 @@
+package mate.academy.bookingapp.dto.payment;
+
+import java.math.BigDecimal;
+import lombok.Data;
+import mate.academy.bookingapp.model.PaymentStatus;
+
+@Data
+public class PaymentDto {
+    private Long id;
+    private Long bookingId;
+    private String sessionUrl;
+    private String sessionId;
+    private BigDecimal amount;
+    private PaymentStatus status;
+}

--- a/src/main/java/mate/academy/bookingapp/mapper/PaymentMapper.java
+++ b/src/main/java/mate/academy/bookingapp/mapper/PaymentMapper.java
@@ -1,0 +1,18 @@
+package mate.academy.bookingapp.mapper;
+
+import mate.academy.bookingapp.config.MapperConfig;
+import mate.academy.bookingapp.dto.payment.PaymentDto;
+import mate.academy.bookingapp.model.Payment;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(config = MapperConfig.class)
+public interface PaymentMapper {
+    @Mapping(target = "bookingId", source = "booking.id")
+    PaymentDto toDto(Payment payment);
+
+    @Mapping(target = "booking.id", source = "bookingId")
+    @Mapping(target = "createdAt", ignore = true)
+    @Mapping(target = "deleted", ignore = true)
+    Payment toModel(PaymentDto paymentDto);
+}

--- a/src/main/java/mate/academy/bookingapp/model/Payment.java
+++ b/src/main/java/mate/academy/bookingapp/model/Payment.java
@@ -11,54 +11,45 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
-import java.time.LocalDate;
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
-import lombok.ToString;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
 
+@Entity
+@Table(name = "payments")
 @Getter
 @Setter
-@Entity
-@Table(name = "bookings")
-@EqualsAndHashCode(onlyExplicitlyIncluded = true)
-@SQLDelete(sql = "UPDATE bookings SET is_deleted = TRUE WHERE id = ?")
+@SQLDelete(sql = "UPDATE payments SET is_deleted = TRUE WHERE id = ?")
 @SQLRestriction("is_deleted = FALSE")
-public class Booking {
+public class Payment {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @EqualsAndHashCode.Include
     private Long id;
 
-    @Column(name = "check_in_date", nullable = false)
-    private LocalDate checkInDate;
-
-    @Column(name = "check_out_date", nullable = false)
-    private LocalDate checkOutDate;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "accommodation_id", nullable = false)
-    @ToString.Exclude
-    private Accommodation accommodation;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = false)
-    @ToString.Exclude
-    private User user;
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "booking_id")
+    private Booking booking;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    private BookingStatus status;
+    private PaymentStatus status;
+
+    @Column(name = "session_url")
+    private String sessionUrl;
+
+    @Column(name = "session_id")
+    private String sessionId;
 
     @Column(nullable = false)
-    @ToString.Exclude
-    private boolean isDeleted;
+    private BigDecimal amount;
 
     @CreationTimestamp
-    @Column(name = "created_at", nullable = false)
+    @Column(name = "created_at", updatable = false)
     private LocalDateTime createdAt;
+
+    private boolean isDeleted = false;
 }

--- a/src/main/java/mate/academy/bookingapp/model/PaymentStatus.java
+++ b/src/main/java/mate/academy/bookingapp/model/PaymentStatus.java
@@ -1,0 +1,8 @@
+package mate.academy.bookingapp.model;
+
+public enum PaymentStatus {
+    PENDING,
+    PAID,
+    EXPIRED,
+    CANCELLED
+}

--- a/src/main/java/mate/academy/bookingapp/repository/payment/PaymentRepository.java
+++ b/src/main/java/mate/academy/bookingapp/repository/payment/PaymentRepository.java
@@ -1,0 +1,26 @@
+package mate.academy.bookingapp.repository.payment;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import mate.academy.bookingapp.model.Payment;
+import mate.academy.bookingapp.model.PaymentStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+public interface PaymentRepository extends JpaRepository<Payment, Long> {
+    @Query("""
+    SELECT p FROM Payment p
+    WHERE p.status = 'PENDING'
+      AND p.createdAt < :cutoffTime
+            """)
+    List<Payment> findPendingBefore(LocalDateTime cutoffTime);
+
+    Page<Payment> findAllByBookingUserId(Long id, Pageable pageable);
+
+    Optional<Payment> findBySessionId(String sessionId);
+
+    boolean existsByBookingIdAndStatus(Long id, PaymentStatus paymentStatus);
+}

--- a/src/main/java/mate/academy/bookingapp/scheduler/BookingCompletionScheduler.java
+++ b/src/main/java/mate/academy/bookingapp/scheduler/BookingCompletionScheduler.java
@@ -10,17 +10,18 @@ import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
-public class BookingExpirationScheduler {
+public class BookingCompletionScheduler {
     private final BookingRepository bookingRepository;
 
-    @Scheduled(cron = "0 * * * * ?")
+    @Scheduled(cron = "0 0 17 * * ?")
     @Transactional
-    public void expirePendingBookings() {
-        LocalDateTime cutoffTime = LocalDateTime.now().minusMinutes(15);
+    public void completeBookings() {
+        LocalDateTime today = LocalDateTime.now().toLocalDate().atStartOfDay();
 
-        bookingRepository.findPendingWithoutPaymentsBefore(cutoffTime)
+        bookingRepository.findAllByStatusAndCheckOutDate(
+                BookingStatus.CONFIRMED, today.toLocalDate())
                 .forEach(booking -> {
-                    booking.setStatus(BookingStatus.EXPIRED);
+                    booking.setStatus(BookingStatus.COMPLETED);
                     bookingRepository.save(booking);
                 });
     }

--- a/src/main/java/mate/academy/bookingapp/scheduler/PaymentExpirationScheduler.java
+++ b/src/main/java/mate/academy/bookingapp/scheduler/PaymentExpirationScheduler.java
@@ -1,0 +1,39 @@
+package mate.academy.bookingapp.scheduler;
+
+import jakarta.transaction.Transactional;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import mate.academy.bookingapp.model.Booking;
+import mate.academy.bookingapp.model.BookingStatus;
+import mate.academy.bookingapp.model.PaymentStatus;
+import mate.academy.bookingapp.repository.booking.BookingRepository;
+import mate.academy.bookingapp.repository.payment.PaymentRepository;
+import mate.academy.bookingapp.service.payment.StripeService;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class PaymentExpirationScheduler {
+    private final PaymentRepository paymentRepository;
+    private final BookingRepository bookingRepository;
+    private final StripeService stripeService;
+
+    @Scheduled(cron = "0 * * * * ?")
+    @Transactional
+    public void expirePendingPayments() {
+        LocalDateTime cutoffTime = LocalDateTime.now().minusMinutes(15);
+
+        paymentRepository.findPendingBefore(cutoffTime).forEach(payment -> {
+            stripeService.expireSession(payment.getSessionId());
+            payment.setStatus(PaymentStatus.EXPIRED);
+            paymentRepository.save(payment);
+
+            Booking booking = payment.getBooking();
+            if (booking.getStatus() == BookingStatus.PENDING) {
+                booking.setStatus(BookingStatus.EXPIRED);
+                bookingRepository.save(booking);
+            }
+        });
+    }
+}

--- a/src/main/java/mate/academy/bookingapp/service/accesscontrol/AccessControlService.java
+++ b/src/main/java/mate/academy/bookingapp/service/accesscontrol/AccessControlService.java
@@ -1,0 +1,35 @@
+package mate.academy.bookingapp.service.accesscontrol;
+
+import lombok.RequiredArgsConstructor;
+import mate.academy.bookingapp.exception.EntityNotFoundException;
+import mate.academy.bookingapp.model.Booking;
+import mate.academy.bookingapp.model.Role;
+import mate.academy.bookingapp.model.User;
+import mate.academy.bookingapp.repository.booking.BookingRepository;
+import mate.academy.bookingapp.service.user.UserService;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AccessControlService {
+    private final UserService userService;
+    private final BookingRepository bookingRepository;
+
+    public void validateBookingOwnership(final Long bookingId) {
+        User currentUser = userService.getCurrentUser();
+        Booking booking = bookingRepository.findById(bookingId)
+                .orElseThrow(() -> new EntityNotFoundException(
+                        "Booking with ID " + bookingId + " not found"));
+
+        if (currentUser.getRoles().stream()
+                .anyMatch(role -> role.getName() == Role.RoleName.ADMIN
+                        || role.getName() == Role.RoleName.SUPER_ADMIN)) {
+            return;
+        }
+
+        if (!booking.getUser().getId().equals(currentUser.getId())) {
+            throw new AccessDeniedException("You do not have permission to access this booking.");
+        }
+    }
+}

--- a/src/main/java/mate/academy/bookingapp/service/booking/BookingServiceImpl.java
+++ b/src/main/java/mate/academy/bookingapp/service/booking/BookingServiceImpl.java
@@ -5,20 +5,16 @@ import lombok.RequiredArgsConstructor;
 import mate.academy.bookingapp.dto.booking.BookingDto;
 import mate.academy.bookingapp.dto.booking.CreateBookingRequestDto;
 import mate.academy.bookingapp.dto.booking.UpdateBookingRequestDto;
-import mate.academy.bookingapp.exception.AccommodationFullyBookedException;
-import mate.academy.bookingapp.exception.EntityNotFoundException;
 import mate.academy.bookingapp.mapper.BookingMapper;
 import mate.academy.bookingapp.model.Accommodation;
 import mate.academy.bookingapp.model.Booking;
 import mate.academy.bookingapp.model.BookingStatus;
-import mate.academy.bookingapp.model.Role;
 import mate.academy.bookingapp.model.User;
-import mate.academy.bookingapp.repository.accommodation.AccommodationRepository;
 import mate.academy.bookingapp.repository.booking.BookingRepository;
+import mate.academy.bookingapp.service.accesscontrol.AccessControlService;
 import mate.academy.bookingapp.service.user.UserService;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -26,16 +22,18 @@ import org.springframework.stereotype.Service;
 @Transactional
 public class BookingServiceImpl implements BookingService {
     private final UserService userService;
-    private final AccommodationRepository accommodationRepository;
     private final BookingRepository bookingRepository;
     private final BookingMapper bookingMapper;
+    private final AccessControlService accessControlService;
+    private final BookingValidationService bookingValidationService;
 
     @Override
     public BookingDto createBooking(final CreateBookingRequestDto requestDto) {
         User currentUser = userService.getCurrentUser();
-        Accommodation accommodation = getAccommodationOrThrow(requestDto.getAccommodationId());
+        Accommodation accommodation =
+                bookingValidationService.getAccommodationOrThrow(requestDto.getAccommodationId());
 
-        checkAvailability(accommodation,
+        bookingValidationService.checkAvailability(accommodation,
                 requestDto.getCheckInDate(),
                 requestDto.getCheckOutDate(),
                 null
@@ -68,26 +66,27 @@ public class BookingServiceImpl implements BookingService {
 
     @Override
     public BookingDto findBookingById(final Long id) {
-        Booking booking = getBookingOrThrow(id);
-        checkUserAccessToBooking(booking);
+        Booking booking = bookingValidationService.getBookingOrThrow(id);
+        accessControlService.validateBookingOwnership(id);
         return bookingMapper.toDto(booking);
     }
 
     @Override
     public BookingDto updateBooking(final Long bookingId,
                                     final UpdateBookingRequestDto requestDto) {
-        Booking booking = getBookingOrThrow(bookingId);
-        checkUserAccessToBooking(booking);
+        Booking booking = bookingValidationService.getBookingOrThrow(bookingId);
+        accessControlService.validateBookingOwnership(bookingId);
 
         if (booking.getStatus() == BookingStatus.CANCELLED
-                || booking.getStatus() == BookingStatus.EXPIRED) {
+                || booking.getStatus() == BookingStatus.EXPIRED
+                || booking.getStatus() == BookingStatus.COMPLETED) {
             throw new IllegalStateException(
                     "Cannot update a booking with status " + booking.getStatus()
             );
 
         }
 
-        checkAvailability(
+        bookingValidationService.checkAvailability(
                 booking.getAccommodation(),
                 requestDto.getCheckInDate(),
                 requestDto.getCheckOutDate(),
@@ -103,8 +102,8 @@ public class BookingServiceImpl implements BookingService {
 
     @Override
     public void cancelBookingById(final Long bookingId) {
-        Booking booking = getBookingOrThrow(bookingId);
-        checkUserAccessToBooking(booking);
+        Booking booking = bookingValidationService.getBookingOrThrow(bookingId);
+        accessControlService.validateBookingOwnership(bookingId);
 
         if (booking.getStatus() == BookingStatus.CANCELLED
                 || booking.getStatus() == BookingStatus.EXPIRED) {
@@ -115,52 +114,5 @@ public class BookingServiceImpl implements BookingService {
 
         booking.setStatus(BookingStatus.CANCELLED);
         bookingRepository.save(booking);
-    }
-
-    private Accommodation getAccommodationOrThrow(final Long accommodationId) {
-        return accommodationRepository.findById(accommodationId)
-                .orElseThrow(() -> new EntityNotFoundException(
-                        "Accommodation with ID " + accommodationId + " not found")
-                );
-    }
-
-    private Booking getBookingOrThrow(final Long bookingId) {
-        return bookingRepository.findById(bookingId)
-                .orElseThrow(() -> new EntityNotFoundException(
-                        "Booking with ID " + bookingId + " not found")
-                );
-    }
-
-    private void checkAvailability(final Accommodation accommodation,
-                                   final java.time.LocalDate checkIn,
-                                   final java.time.LocalDate checkOut,
-                                   final Long excludeBookingId) {
-        long overlappingCount = (excludeBookingId == null)
-                ? bookingRepository.countOverlappingBookings(
-                        accommodation.getId(), checkIn, checkOut)
-                : bookingRepository.countOverlappingBookings(
-                        accommodation.getId(), excludeBookingId, checkIn, checkOut);
-
-        if (overlappingCount >= accommodation.getAvailability()) {
-            throw new AccommodationFullyBookedException(
-                    "Accommodation is fully booked for the given dates"
-            );
-        }
-    }
-
-    private void checkUserAccessToBooking(final Booking booking) {
-        User currentUser = userService.getCurrentUser();
-
-        if (currentUser.getRoles().stream()
-                .anyMatch(role -> role.getName() == Role.RoleName.ADMIN
-                        || role.getName() == Role.RoleName.SUPER_ADMIN)) {
-            return;
-        }
-
-        if (!booking.getUser().getId().equals(currentUser.getId())) {
-            throw new AccessDeniedException(
-                    "You do not have access to booking with ID " + booking.getId()
-            );
-        }
     }
 }

--- a/src/main/java/mate/academy/bookingapp/service/booking/BookingValidationService.java
+++ b/src/main/java/mate/academy/bookingapp/service/booking/BookingValidationService.java
@@ -1,0 +1,46 @@
+package mate.academy.bookingapp.service.booking;
+
+import java.time.LocalDate;
+import lombok.RequiredArgsConstructor;
+import mate.academy.bookingapp.exception.AccommodationFullyBookedException;
+import mate.academy.bookingapp.exception.EntityNotFoundException;
+import mate.academy.bookingapp.model.Accommodation;
+import mate.academy.bookingapp.model.Booking;
+import mate.academy.bookingapp.repository.accommodation.AccommodationRepository;
+import mate.academy.bookingapp.repository.booking.BookingRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class BookingValidationService {
+    private final BookingRepository bookingRepository;
+    private final AccommodationRepository accommodationRepository;
+
+    public Booking getBookingOrThrow(final Long bookingId) {
+        return bookingRepository.findById(bookingId)
+                .orElseThrow(() -> new EntityNotFoundException(
+                        "Booking with ID " + bookingId + " not found"));
+    }
+
+    public Accommodation getAccommodationOrThrow(final Long accommodationId) {
+        return accommodationRepository.findById(accommodationId)
+                .orElseThrow(() -> new EntityNotFoundException(
+                        "Accommodation with ID " + accommodationId + " not found"));
+    }
+
+    public void checkAvailability(final Accommodation accommodation,
+                                  final LocalDate checkIn,
+                                  final LocalDate checkOut,
+                                  final Long excludeBookingId) {
+        long overlappingCount = (excludeBookingId == null)
+                ? bookingRepository.countOverlappingBookings(
+                        accommodation.getId(), checkIn, checkOut)
+                : bookingRepository.countOverlappingBookings(
+                        accommodation.getId(), excludeBookingId, checkIn, checkOut);
+
+        if (overlappingCount >= accommodation.getAvailability()) {
+            throw new AccommodationFullyBookedException(
+                    "Accommodation is fully booked for the given dates");
+        }
+    }
+}

--- a/src/main/java/mate/academy/bookingapp/service/payment/PaymentService.java
+++ b/src/main/java/mate/academy/bookingapp/service/payment/PaymentService.java
@@ -1,0 +1,19 @@
+package mate.academy.bookingapp.service.payment;
+
+import mate.academy.bookingapp.dto.payment.PaymentDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface PaymentService {
+    PaymentDto createPaymentSession(Long bookingId, String successUrl, String cancelUrl);
+
+    String handleSuccess(String sessionId);
+
+    String handleCancel(String sessionId);
+
+    Page<PaymentDto> getCurrentUserPayments(Pageable pageable);
+
+    Page<PaymentDto> findAllByUserId(Long userId, Pageable pageable);
+
+    Page<PaymentDto> getAllPayments(Pageable pageable);
+}

--- a/src/main/java/mate/academy/bookingapp/service/payment/PaymentServiceImpl.java
+++ b/src/main/java/mate/academy/bookingapp/service/payment/PaymentServiceImpl.java
@@ -1,0 +1,131 @@
+package mate.academy.bookingapp.service.payment;
+
+import com.stripe.model.checkout.Session;
+import jakarta.transaction.Transactional;
+import java.math.BigDecimal;
+import lombok.RequiredArgsConstructor;
+import mate.academy.bookingapp.dto.payment.PaymentDto;
+import mate.academy.bookingapp.mapper.PaymentMapper;
+import mate.academy.bookingapp.model.Booking;
+import mate.academy.bookingapp.model.BookingStatus;
+import mate.academy.bookingapp.model.Payment;
+import mate.academy.bookingapp.model.PaymentStatus;
+import mate.academy.bookingapp.model.User;
+import mate.academy.bookingapp.repository.booking.BookingRepository;
+import mate.academy.bookingapp.repository.payment.PaymentRepository;
+import mate.academy.bookingapp.service.accesscontrol.AccessControlService;
+import mate.academy.bookingapp.service.user.UserService;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class PaymentServiceImpl implements PaymentService {
+    private final BookingRepository bookingRepository;
+    private final PaymentRepository paymentRepository;
+    private final PaymentMapper paymentMapper;
+    private final UserService userService;
+    private final AccessControlService accessControlService;
+    private final PaymentValidationService paymentValidationService;
+    private final StripeService stripeService;
+
+    @Override
+    public PaymentDto createPaymentSession(final Long bookingId,
+                                           final String successUrl,
+                                           final String cancelUrl) {
+        Booking booking = paymentValidationService.getBookingOrThrow(bookingId, bookingRepository);
+
+        accessControlService.validateBookingOwnership(bookingId);
+        paymentValidationService.validateBookingStatus(booking);
+        paymentValidationService.validatePendingPaymentsForBooking(
+                booking.getId(), paymentRepository
+        );
+
+        BigDecimal totalAmount = paymentValidationService.calculateTotalPrice(booking);
+        Session session = stripeService.createStripeSession(
+                booking, totalAmount, successUrl, cancelUrl
+        );
+
+        Payment payment = savePayment(booking, totalAmount, session);
+
+        booking.setCreatedAt(payment.getCreatedAt());
+        bookingRepository.save(booking);
+
+        return paymentMapper.toDto(payment);
+    }
+
+    @Override
+    public String handleSuccess(final String sessionId) {
+        Payment payment = paymentValidationService.getPaymentOrThrow(sessionId, paymentRepository);
+        accessControlService.validateBookingOwnership(payment.getBooking().getId());
+
+        Session session = stripeService.retrieveSession(sessionId);
+
+        if ("paid".equals(session.getPaymentStatus())) {
+            payment.setStatus(PaymentStatus.PAID);
+            Booking booking = payment.getBooking();
+            if (booking.getStatus() == BookingStatus.PENDING) {
+                booking.setStatus(BookingStatus.CONFIRMED);
+            }
+            paymentRepository.save(payment);
+            return "Payment successfully completed for session: " + sessionId;
+        }
+
+        return "Payment not completed yet for session: " + sessionId
+                + ". Current status: " + session.getPaymentStatus();
+    }
+
+    @Override
+    public String handleCancel(final String sessionId) {
+        Payment payment = paymentValidationService.getPaymentOrThrow(sessionId, paymentRepository);
+        stripeService.expireSession(sessionId);
+
+        payment.setStatus(PaymentStatus.CANCELLED);
+        paymentRepository.save(payment);
+
+        Booking booking = payment.getBooking();
+        if (booking.getStatus() == BookingStatus.PENDING) {
+            booking.setStatus(BookingStatus.EXPIRED);
+        }
+
+        bookingRepository.save(booking);
+        return "Payment session with ID " + sessionId
+                + " has been canceled, and booking marked as EXPIRED.";
+    }
+
+    @Override
+    public Page<PaymentDto> getCurrentUserPayments(final Pageable pageable) {
+        User currentUser = userService.getCurrentUser();
+        return findAllByUserId(currentUser.getId(), pageable);
+    }
+
+    @Override
+    public Page<PaymentDto> findAllByUserId(final Long userId, Pageable pageable) {
+        paymentValidationService.findUserOrThrow(userId);
+        return paymentRepository.findAllByBookingUserId(userId, pageable)
+                .map(paymentMapper::toDto);
+    }
+
+    @Override
+    public Page<PaymentDto> getAllPayments(final Pageable pageable) {
+        User currentUser = userService.getCurrentUser();
+        if (paymentValidationService.isAdminOrSuperAdmin(currentUser)) {
+            return paymentRepository.findAll(pageable).map(paymentMapper::toDto);
+        }
+        return findAllByUserId(currentUser.getId(), pageable);
+    }
+
+    private Payment savePayment(final Booking booking,
+                                final BigDecimal totalAmount,
+                                final Session session) {
+        Payment payment = new Payment();
+        payment.setBooking(booking);
+        payment.setAmount(totalAmount);
+        payment.setSessionUrl(session.getUrl());
+        payment.setSessionId(session.getId());
+        payment.setStatus(PaymentStatus.PENDING);
+        return paymentRepository.save(payment);
+    }
+}

--- a/src/main/java/mate/academy/bookingapp/service/payment/PaymentValidationService.java
+++ b/src/main/java/mate/academy/bookingapp/service/payment/PaymentValidationService.java
@@ -1,0 +1,82 @@
+package mate.academy.bookingapp.service.payment;
+
+import java.math.BigDecimal;
+import java.time.temporal.ChronoUnit;
+import lombok.RequiredArgsConstructor;
+import mate.academy.bookingapp.exception.EntityNotFoundException;
+import mate.academy.bookingapp.model.Booking;
+import mate.academy.bookingapp.model.BookingStatus;
+import mate.academy.bookingapp.model.Payment;
+import mate.academy.bookingapp.model.PaymentStatus;
+import mate.academy.bookingapp.model.Role;
+import mate.academy.bookingapp.model.User;
+import mate.academy.bookingapp.repository.booking.BookingRepository;
+import mate.academy.bookingapp.repository.payment.PaymentRepository;
+import mate.academy.bookingapp.repository.user.UserRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PaymentValidationService {
+    private final UserRepository userRepository;
+
+    public Booking getBookingOrThrow(final Long bookingId,
+                                     final BookingRepository bookingRepository) {
+        return bookingRepository.findById(bookingId)
+                .orElseThrow(() -> new EntityNotFoundException(
+                        "Booking with ID " + bookingId + " not found"));
+    }
+
+    public Payment getPaymentOrThrow(final String sessionId,
+                                     final PaymentRepository paymentRepository) {
+        return paymentRepository.findBySessionId(sessionId)
+                .orElseThrow(() -> new EntityNotFoundException(
+                        "Payment not found for session: " + sessionId));
+    }
+
+    public void findUserOrThrow(final Long userId) {
+        userRepository.findById(userId)
+                .orElseThrow(() -> new EntityNotFoundException(
+                        "User with ID " + userId + " not found"));
+    }
+
+    public void validateBookingStatus(final Booking booking) {
+        if (booking.getStatus() != BookingStatus.PENDING) {
+            throw new IllegalArgumentException(
+                    "Cannot create payment for booking with status " + booking.getStatus());
+        }
+    }
+
+    public void validatePendingPaymentsForBooking(final Long bookingId,
+                                                  final PaymentRepository paymentRepository) {
+        boolean hasPendingPayments
+                = paymentRepository.existsByBookingIdAndStatus(bookingId, PaymentStatus.PENDING);
+        if (hasPendingPayments) {
+            throw new IllegalArgumentException(
+                    "A pending payment already exists for this booking.");
+        }
+    }
+
+    public BigDecimal calculateTotalPrice(final Booking booking) {
+        if (booking.getAccommodation().getDailyRate() == null) {
+            throw new IllegalArgumentException("Accommodation daily rate is not set");
+        }
+        if (booking.getCheckInDate() == null || booking.getCheckOutDate() == null) {
+            throw new IllegalArgumentException("Booking dates are not specified");
+        }
+
+        long days = ChronoUnit.DAYS.between(booking.getCheckInDate(), booking.getCheckOutDate());
+        if (days <= 0) {
+            throw new IllegalArgumentException(
+                    "Invalid booking dates: check-out must be after check-in");
+        }
+
+        return booking.getAccommodation().getDailyRate().multiply(BigDecimal.valueOf(days));
+    }
+
+    public boolean isAdminOrSuperAdmin(final User user) {
+        return user.getRoles().stream()
+                .anyMatch(role -> role.getName() == Role.RoleName.ADMIN
+                        || role.getName() == Role.RoleName.SUPER_ADMIN);
+    }
+}

--- a/src/main/java/mate/academy/bookingapp/service/payment/StripeService.java
+++ b/src/main/java/mate/academy/bookingapp/service/payment/StripeService.java
@@ -1,0 +1,58 @@
+package mate.academy.bookingapp.service.payment;
+
+import com.stripe.exception.StripeException;
+import com.stripe.model.checkout.Session;
+import com.stripe.param.checkout.SessionCreateParams;
+import java.math.BigDecimal;
+import mate.academy.bookingapp.model.Booking;
+import org.springframework.stereotype.Service;
+
+@Service
+public class StripeService {
+    public Session retrieveSession(final String sessionId) {
+        try {
+            return Session.retrieve(sessionId);
+        } catch (StripeException e) {
+            throw new RuntimeException("Error retrieving session from Stripe", e);
+        }
+    }
+
+    public void expireSession(final String sessionId) {
+        try {
+            Session session = Session.retrieve(sessionId);
+            if ("open".equals(session.getStatus())) {
+                session.expire();
+            }
+        } catch (StripeException e) {
+            throw new RuntimeException("Error expiring session in Stripe", e);
+        }
+    }
+
+    public Session createStripeSession(final Booking booking,
+                                       final BigDecimal totalAmount,
+                                       final String successUrl,
+                                       final String cancelUrl) {
+        SessionCreateParams params = SessionCreateParams.builder()
+                .addLineItem(SessionCreateParams.LineItem.builder()
+                        .setQuantity(1L)
+                        .setPriceData(SessionCreateParams.LineItem.PriceData.builder()
+                                .setCurrency("usd")
+                                .setUnitAmount(totalAmount.movePointRight(2).longValue())
+                                .setProductData(SessionCreateParams.LineItem
+                                        .PriceData.ProductData.builder()
+                                        .setName("Booking #" + booking.getId())
+                                        .build())
+                                .build())
+                        .build())
+                .setMode(SessionCreateParams.Mode.PAYMENT)
+                .setSuccessUrl(successUrl)
+                .setCancelUrl(cancelUrl)
+                .build();
+
+        try {
+            return Session.create(params);
+        } catch (StripeException e) {
+            throw new RuntimeException("Error creating Stripe session", e);
+        }
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -14,3 +14,6 @@ server.servlet.context-path=/api
 
 jwt.expiration=3600000
 jwt.secret=bookingappjedt7h08g37fowvijypw8w0qixcs
+
+stripe.api.secret-key=
+stripe.api.public-key=

--- a/src/main/resources/db/changelog/changes/11-create-payments-table.yaml
+++ b/src/main/resources/db/changelog/changes/11-create-payments-table.yaml
@@ -1,0 +1,58 @@
+databaseChangeLog:
+  - changeSet:
+      id: create-payments-table
+      author: pavlo_melnyk
+      changes:
+        - createTable:
+            tableName: payments
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: booking_id
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+              - column:
+                  name: status
+                  type: VARCHAR(50)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: session_url
+                  type: VARCHAR(500)
+                  constraints:
+                    nullable: true
+              - column:
+                  name: session_id
+                  type: VARCHAR(255)
+                  constraints:
+                    nullable: true
+              - column:
+                  name: amount
+                  type: DECIMAL(19,2)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: created_at
+                  type: TIMESTAMP
+                  constraints:
+                    nullable: false
+                  defaultValueComputed: CURRENT_TIMESTAMP
+              - column:
+                  name: is_deleted
+                  type: BOOLEAN
+                  defaultValueBoolean: false
+                  constraints:
+                    nullable: false
+        - addForeignKeyConstraint:
+            baseTableName: payments
+            baseColumnNames: booking_id
+            constraintName: fk_payments_booking
+            referencedTableName: bookings
+            referencedColumnNames: id

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -19,3 +19,5 @@ databaseChangeLog:
       file: db/changelog/changes/09-create-accommodation-amenities-table.yaml
   - include:
       file: db/changelog/changes/10-create-bookings-table.yaml
+  - include:
+      file: db/changelog/changes/11-create-payments-table.yaml


### PR DESCRIPTION
- Payment Controller:
  - Added endpoints in `PaymentController`:
    - `POST /payments`: Create a new payment session for a booking
    - `GET /payments/success`: Handle successful payment processing
    - `GET /payments/cancel`: Handle payment cancellation
    - `GET /payments/my`: Retrieve payments for the currently authenticated user
    - `GET /payments`: Allow admins to retrieve payments filtered by user ID
    - `GET /payments/all`: Allow admins to retrieve all payments
  - Added Swagger documentation for all endpoints

- Stripe Integration:
  - Automated Stripe payment session creation:
    - Dynamically generated success and cancel URLs.
    - Calculated the total price of the booking and set it as the Stripe session amount
    - Captured the session URL and session ID for storage in the database
    - Automatically extended the `createdAt` timestamp of the associated booking to match the payment's expiration time, ensuring the booking remains active for the 15-minute payment window

- Scheduling:
  - Added `PaymentExpirationScheduler` to expire `PENDING` payments after 15 minutes if not completed:
    - Closed Stripe sessions automatically
    - Marked associated bookings as `EXPIRED`
  - Added `BookingCompletionScheduler` to marks bookings as `COMPLETED` when the `checkOutDate` matches the current date. Runs daily at 17:00 to process bookings with status `CONFIRMED` and `checkOutDate` as today